### PR TITLE
Improve Clan Command: Move Clan Accept & Deny Command from Subcommand to Main Command.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,10 +3,6 @@
   <component name="ComposerSettings">
     <execution />
   </component>
-  <component name="DiscordProjectSettings">
-    <option name="show" value="ASK" />
-    <option name="description" value="" />
-  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />

--- a/surf-clan-velocity/src/main/kotlin/dev/slne/clan/velocity/commands/ClanCommand.kt
+++ b/surf-clan-velocity/src/main/kotlin/dev/slne/clan/velocity/commands/ClanCommand.kt
@@ -7,6 +7,8 @@ import dev.slne.clan.velocity.commands.subcommands.*
 import dev.slne.clan.velocity.commands.subcommands.admin.ClanAdminCommand
 import dev.slne.clan.velocity.commands.subcommands.member.ClanKickMemberCommand
 import dev.slne.clan.velocity.commands.subcommands.member.ClanMembersCommand
+import dev.slne.clan.velocity.commands.subcommands.member.invite.ClanInviteAcceptCommand
+import dev.slne.clan.velocity.commands.subcommands.member.invite.ClanInviteDenyCommand
 import dev.slne.clan.velocity.commands.subcommands.member.invite.ClanInviteMemberCommand
 import dev.slne.clan.velocity.commands.subcommands.member.role.ClanDemoteMemberCommand
 import dev.slne.clan.velocity.commands.subcommands.member.role.ClanPromoteMemberCommand
@@ -28,6 +30,9 @@ class ClanCommand(
         withSubcommand(ClanDemoteMemberCommand(clanService, clanPlayerService))
         withSubcommand(ClanKickMemberCommand(clanService, clanPlayerService))
         withSubcommand(ClanMembersCommand(clanService, clanPlayerService))
+
+        withSubcommands(ClanInviteAcceptCommand(clanService, clanPlayerService))
+        withSubcommands(ClanInviteDenyCommand(clanService, clanPlayerService))
 
         withSubcommand(ClanPlayerCommand(clanService, clanPlayerService))
         withSubcommand(ClanAdminCommand(clanService))

--- a/surf-clan-velocity/src/main/kotlin/dev/slne/clan/velocity/commands/subcommands/member/invite/ClanInviteMemberCommand.kt
+++ b/surf-clan-velocity/src/main/kotlin/dev/slne/clan/velocity/commands/subcommands/member/invite/ClanInviteMemberCommand.kt
@@ -28,9 +28,6 @@ class ClanInviteMemberCommand(
     init {
         withPermission("surf.clan.invite")
 
-        withSubcommands(ClanInviteAcceptCommand(clanService, clanPlayerService))
-        withSubcommands(ClanInviteDenyCommand(clanService, clanPlayerService))
-
         playerArgument()
 
         playerExecutor { player, args ->


### PR DESCRIPTION
This pull request includes updates to the `surf-clan-velocity` project, focusing on improving the organization of clan-related commands and cleaning up unnecessary configuration in the `.idea` folder. The key changes include restructuring subcommands for clan invites and removing redundant IDE settings.

### Command Restructuring:
* [`surf-clan-velocity/src/main/kotlin/dev/slne/clan/velocity/commands/ClanCommand.kt`](diffhunk://#diff-894cfdebd6527b173ec5982e102a46d3aa172f3314c4c08755250bf9440512e7R34-R36): Added `ClanInviteAcceptCommand` and `ClanInviteDenyCommand` as top-level subcommands under `ClanCommand`, improving clarity in the command hierarchy.
* [`surf-clan-velocity/src/main/kotlin/dev/slne/clan/velocity/commands/subcommands/member/invite/ClanInviteMemberCommand.kt`](diffhunk://#diff-62e42d13c71506193eb7dda688550848ffadbb0872aef54a390f11a9a93880c2L31-L33): Removed `ClanInviteAcceptCommand` and `ClanInviteDenyCommand` as subcommands of `ClanInviteMemberCommand`, reflecting their promotion to top-level subcommands.
* [`surf-clan-velocity/src/main/kotlin/dev/slne/clan/velocity/commands/ClanCommand.kt`](diffhunk://#diff-894cfdebd6527b173ec5982e102a46d3aa172f3314c4c08755250bf9440512e7R10-R11): Updated imports to include the newly added top-level subcommands.

fixed #7 