### PR TITLE
Add Clan RPC services for management and invite operations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.daemon=true
 kapt.use.k2=true
 kapt.include.compile.classpath=false
 kotlin.stdlib.default.dependency=false
-version=2.1.2
+version=2.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.daemon=true
 kapt.use.k2=true
 kapt.include.compile.classpath=false
 kotlin.stdlib.default.dependency=false
-version=2.1.1
+version=2.1.2

--- a/surf-clan-api/src/main/kotlin/dev/slne/clan/api/clan/ClanCreateBuilder.kt
+++ b/surf-clan-api/src/main/kotlin/dev/slne/clan/api/clan/ClanCreateBuilder.kt
@@ -1,6 +1,5 @@
 package dev.slne.clan.api.clan
 
-import net.kyori.adventure.text.format.TextColor
 import java.util.*
 
 /**

--- a/surf-clan-core/src/main/kotlin/dev/slne/surf/clan/core/rpc/ClanInviteRpcService.kt
+++ b/surf-clan-core/src/main/kotlin/dev/slne/surf/clan/core/rpc/ClanInviteRpcService.kt
@@ -1,0 +1,18 @@
+package dev.slne.surf.clan.core.rpc
+
+import dev.slne.clan.api.invite.ClanInviteResult
+import dev.slne.surf.clan.core.invite.ClanInviteImpl
+import dev.slne.surf.rabbitmq.api.rpc.RpcService
+import java.util.*
+
+@RpcService
+interface ClanInviteRpcService {
+
+    suspend fun acceptInvite(inviteID: ULong, invitee: UUID, invitedBy: UUID): Boolean
+    suspend fun createInvite(clanID: ULong, invitee: UUID, invitedBy: UUID): ClanInviteResult
+    suspend fun deleteInvite(clanID: ULong, invitee: UUID): Boolean
+
+    suspend fun findPendingInvitesByClanId(clanID: ULong): Set<ClanInviteImpl>
+    suspend fun findPendingInvitesByInvited(invited: UUID): List<ClanInviteImpl>
+    suspend fun findPendingInviteByClanNameAndInvited(clanName: String, invited: UUID): ClanInviteImpl?
+}

--- a/surf-clan-core/src/main/kotlin/dev/slne/surf/clan/core/rpc/ClanMemberRpcService.kt
+++ b/surf-clan-core/src/main/kotlin/dev/slne/surf/clan/core/rpc/ClanMemberRpcService.kt
@@ -1,0 +1,18 @@
+package dev.slne.surf.clan.core.rpc
+
+import dev.slne.clan.api.member.ClanMemberAddResult
+import dev.slne.clan.api.member.ClanMemberRole
+import dev.slne.surf.clan.core.member.ClanMemberImpl
+import dev.slne.surf.rabbitmq.api.rpc.RpcService
+import java.util.*
+
+@RpcService
+interface ClanMemberRpcService {
+
+    suspend fun createMember(clanID: ULong, player: UUID, role: ClanMemberRole, invitedBy: UUID?): ClanMemberAddResult
+    suspend fun deleteMember(clanID: ULong, player: UUID): Boolean
+
+    suspend fun changeMemberRole(memberID: ULong, role: ClanMemberRole): Boolean
+
+    suspend fun findMemberByUUID(uuid: UUID): ClanMemberImpl?
+}

--- a/surf-clan-core/src/main/kotlin/dev/slne/surf/clan/core/rpc/ClanPlayerRpcService.kt
+++ b/surf-clan-core/src/main/kotlin/dev/slne/surf/clan/core/rpc/ClanPlayerRpcService.kt
@@ -1,0 +1,13 @@
+package dev.slne.surf.clan.core.rpc
+
+import dev.slne.surf.clan.core.player.ClanPlayerImpl
+import dev.slne.surf.rabbitmq.api.rpc.RpcService
+import java.util.*
+
+@RpcService
+interface ClanPlayerRpcService {
+
+    suspend fun findClanPlayerByUuid(uuid: UUID): ClanPlayerImpl
+    suspend fun updateAcceptsClanInvites(playerID: ULong, acceptsClanInvites: Boolean): Boolean
+
+}

--- a/surf-clan-core/src/main/kotlin/dev/slne/surf/clan/core/rpc/ClanRpcService.kt
+++ b/surf-clan-core/src/main/kotlin/dev/slne/surf/clan/core/rpc/ClanRpcService.kt
@@ -1,0 +1,41 @@
+package dev.slne.surf.clan.core.rpc
+
+import dev.slne.clan.api.clan.ClanCreationResult
+import dev.slne.surf.clan.core.clan.ClanImpl
+import dev.slne.surf.rabbitmq.api.rpc.RpcService
+import net.kyori.adventure.text.format.ShadowColor
+import net.kyori.adventure.text.format.TextColor
+import java.util.*
+
+@RpcService
+interface ClanRpcService {
+
+    suspend fun createClan(
+        name: String,
+        tag: String,
+        owner: UUID,
+        tagForegroundColor: TextColor?,
+        tagBackgroundColor: TextColor?,
+        tagShadowColor: ShadowColor?,
+        description: String?,
+        discordInvite: String?
+    ): ClanCreationResult
+
+    suspend fun deleteClan(clanID: ULong): Boolean
+
+    suspend fun findAllClansWithoutMembersSortByMemberCount(): Collection<ClanImpl>
+    suspend fun findClanById(clanID: ULong): ClanImpl?
+    suspend fun findClanByMember(memberUuid: UUID): ClanImpl?
+    suspend fun findClanByTag(tag: String): ClanImpl?
+    suspend fun findClanByClanUuid(clanUuid: UUID): ClanImpl?
+    suspend fun findClanTagsByPrefix(prefix: String, limit: Int): List<String>
+
+    suspend fun updateClanDescription(clanID: ULong, description: String?): Boolean
+    suspend fun updateClanDiscordInvite(clanID: ULong, discordInvite: String?): Boolean
+    suspend fun updateClanTagColor(
+        clanID: ULong,
+        tagForegroundColor: TextColor?,
+        tagBackgroundColor: TextColor?,
+        tagShadowColor: ShadowColor?
+    ): Boolean
+}

--- a/surf-clan-core/surf-clan-core-client/src/main/kotlin/dev/slne/surf/clan/core/client/rpc/RpcServices.kt
+++ b/surf-clan-core/surf-clan-core-client/src/main/kotlin/dev/slne/surf/clan/core/client/rpc/RpcServices.kt
@@ -1,6 +1,12 @@
 package dev.slne.surf.clan.core.client.rpc
 
 import dev.slne.surf.clan.core.client.rabbit.rabbitApi
+import dev.slne.surf.clan.core.rpc.ClanInviteRpcService
+import dev.slne.surf.clan.core.rpc.ClanMemberRpcService
+import dev.slne.surf.clan.core.rpc.ClanPlayerRpcService
 import dev.slne.surf.clan.core.rpc.ClanRpcService
 
 val clanRpcService by lazy { rabbitApi.createRpcService<ClanRpcService>() }
+val clanInviteRpcService by lazy { rabbitApi.createRpcService<ClanInviteRpcService>() }
+val clanMemberRpcService by lazy { rabbitApi.createRpcService<ClanMemberRpcService>() }
+val clanPlayerRpcService by lazy { rabbitApi.createRpcService<ClanPlayerRpcService>() }

--- a/surf-clan-core/surf-clan-core-client/src/main/kotlin/dev/slne/surf/clan/core/client/rpc/RpcServices.kt
+++ b/surf-clan-core/surf-clan-core-client/src/main/kotlin/dev/slne/surf/clan/core/client/rpc/RpcServices.kt
@@ -1,0 +1,6 @@
+package dev.slne.surf.clan.core.client.rpc
+
+import dev.slne.surf.clan.core.client.rabbit.rabbitApi
+import dev.slne.surf.clan.core.rpc.ClanRpcService
+
+val clanRpcService by lazy { rabbitApi.createRpcService<ClanRpcService>() }

--- a/surf-clan-core/surf-clan-core-client/src/main/kotlin/dev/slne/surf/clan/core/client/services/ClientClanInviteServiceImpl.kt
+++ b/surf-clan-core/surf-clan-core-client/src/main/kotlin/dev/slne/surf/clan/core/client/services/ClientClanInviteServiceImpl.kt
@@ -6,35 +6,26 @@ import dev.slne.clan.api.invite.ClanInviteAcceptResult
 import dev.slne.clan.api.invite.ClanInviteResult
 import dev.slne.clan.api.invite.ClanInviteService
 import dev.slne.surf.clan.core.clan.CoreClanService
-import dev.slne.surf.clan.core.client.rabbit.rabbitApi
+import dev.slne.surf.clan.core.client.rpc.clanInviteRpcService
 import dev.slne.surf.clan.core.invite.ClanInviteImpl
 import dev.slne.surf.clan.core.invite.CoreClanInviteService
-import dev.slne.surf.clan.core.protocol.invite.accept.AcceptClanInviteRequestPacket
-import dev.slne.surf.clan.core.protocol.invite.create.CreateClanInviteRequestPacket
-import dev.slne.surf.clan.core.protocol.invite.delete.DeleteInviteClanInviteRequestPacket
-import dev.slne.surf.clan.core.protocol.invite.findPendingByClanID.FindPendingInvitesByClanIDRequestPacket
-import dev.slne.surf.clan.core.protocol.invite.findPendingByInvited.FindPendingInvitesByInvitedRequestPacket
-import dev.slne.surf.clan.core.protocol.invite.findPendingByInvitedAndClanName.FindPendingInviteByInvitedPlayerAndClanNameRequestPacket
 import java.util.*
 
 @AutoService(ClanInviteService::class)
 class ClientClanInviteServiceImpl : CoreClanInviteService {
     override suspend fun fetchPendingInvites(clanID: ULong): Set<ClanInviteImpl> {
-        val request = FindPendingInvitesByClanIDRequestPacket(clanID)
-        return rabbitApi.sendRequest(request).invites
+        return clanInviteRpcService.findPendingInvitesByClanId(clanID)
     }
 
     override suspend fun getPendingInviteByPlayerAndClanName(
         invited: UUID,
         clanName: String
     ): ClanInvite? {
-        val request = FindPendingInviteByInvitedPlayerAndClanNameRequestPacket(invited, clanName)
-        return rabbitApi.sendRequest(request).invite
+        return clanInviteRpcService.findPendingInviteByClanNameAndInvited(clanName, invited)
     }
 
     override suspend fun getPendingInvitesByPlayer(invited: UUID): List<ClanInvite> {
-        val request = FindPendingInvitesByInvitedRequestPacket(invited)
-        return rabbitApi.sendRequest(request).invites
+        return clanInviteRpcService.findPendingInvitesByInvited(invited)
     }
 
     override suspend fun createInvite(
@@ -42,13 +33,11 @@ class ClientClanInviteServiceImpl : CoreClanInviteService {
         invitee: UUID,
         invitedBy: UUID
     ): ClanInviteResult {
-        val request = CreateClanInviteRequestPacket(clanID, invitee, invitedBy)
-        return rabbitApi.sendRequest(request).result
+        return clanInviteRpcService.createInvite(clanID, invitee, invitedBy)
     }
 
     override suspend fun deleteInvite(clanID: ULong, invitee: UUID): Boolean {
-        val request = DeleteInviteClanInviteRequestPacket(clanID, invitee)
-        return rabbitApi.sendRequest(request).value
+        return clanInviteRpcService.deleteInvite(clanID, invitee)
     }
 
     override suspend fun revokeInvite(invite: ClanInviteImpl): Boolean {
@@ -56,8 +45,7 @@ class ClientClanInviteServiceImpl : CoreClanInviteService {
     }
 
     override suspend fun acceptInvite(invite: ClanInviteImpl): ClanInviteAcceptResult {
-        val request = AcceptClanInviteRequestPacket(invite.id, invite.invited, invite.invitedBy)
-        val accepted = rabbitApi.sendRequest(request).value
+        val accepted = clanInviteRpcService.acceptInvite(invite.id, invite.invited, invite.invitedBy)
 
         if (!accepted) {
             return ClanInviteAcceptResult.AlreadyInClan

--- a/surf-clan-core/surf-clan-core-client/src/main/kotlin/dev/slne/surf/clan/core/client/services/ClientClanMemberServiceImpl.kt
+++ b/surf-clan-core/surf-clan-core-client/src/main/kotlin/dev/slne/surf/clan/core/client/services/ClientClanMemberServiceImpl.kt
@@ -10,13 +10,9 @@ import dev.slne.clan.api.member.listener.ClanMemberChangedRoleListener
 import dev.slne.clan.api.member.listener.ClanMemberListener
 import dev.slne.surf.api.core.service.PlayerLookupService
 import dev.slne.surf.api.core.util.logger
-import dev.slne.surf.clan.core.client.rabbit.rabbitApi
+import dev.slne.surf.clan.core.client.rpc.clanMemberRpcService
 import dev.slne.surf.clan.core.member.ClanMemberImpl
 import dev.slne.surf.clan.core.member.CoreClanMemberService
-import dev.slne.surf.clan.core.protocol.member.changeRole.ChangeClanMemberRoleRequestPacket
-import dev.slne.surf.clan.core.protocol.member.create.CreateClanMemberRequestPacket
-import dev.slne.surf.clan.core.protocol.member.delete.DeleteClanMemberRequestPacket
-import dev.slne.surf.clan.core.protocol.member.findByUuid.FindClanMemberByUuidRequestPacket
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -70,8 +66,7 @@ class ClientClanMemberServiceImpl : CoreClanMemberService {
         val member = loadedMembers.getIfPresent(uuid)
         if (member != null) return member
 
-        val request = FindClanMemberByUuidRequestPacket(uuid)
-        val loaded = rabbitApi.sendRequest(request).member ?: return null
+        val loaded = clanMemberRpcService.findMemberByUUID(uuid) ?: return null
         loadedMembers.put(uuid, loaded)
 
         return loaded
@@ -83,8 +78,7 @@ class ClientClanMemberServiceImpl : CoreClanMemberService {
         role: ClanMemberRole,
         invitedBy: UUID?
     ): ClanMemberAddResult {
-        val request = CreateClanMemberRequestPacket(clanID, player, role, invitedBy)
-        val result = rabbitApi.sendRequest(request).result
+        val result = clanMemberRpcService.createMember(clanID, player, role, invitedBy)
 
         if (result is ClanMemberAddResult.Success) {
             ClientClanServiceImpl.get().invalidateCachedClanByID(clanID)
@@ -94,8 +88,7 @@ class ClientClanMemberServiceImpl : CoreClanMemberService {
     }
 
     override suspend fun removeMember(clanID: ULong, player: UUID): Boolean {
-        val request = DeleteClanMemberRequestPacket(clanID, player)
-        val result = rabbitApi.sendRequest(request).value
+        val result = clanMemberRpcService.deleteMember(clanID, player)
 
         if (result) {
             ClientClanServiceImpl.get().invalidateCachedClanByID(clanID)
@@ -108,8 +101,7 @@ class ClientClanMemberServiceImpl : CoreClanMemberService {
         member: ClanMemberImpl,
         role: ClanMemberRole
     ): Boolean {
-        val request = ChangeClanMemberRoleRequestPacket(member.ID, role)
-        val changed = rabbitApi.sendRequest(request).value
+        val changed = clanMemberRpcService.changeMemberRole(member.ID, role)
 
         if (changed) {
             ClientClanServiceImpl.get().invalidateCachedClanByMember(member.uuid)

--- a/surf-clan-core/surf-clan-core-client/src/main/kotlin/dev/slne/surf/clan/core/client/services/ClientClanPlayerServiceImpl.kt
+++ b/surf-clan-core/surf-clan-core-client/src/main/kotlin/dev/slne/surf/clan/core/client/services/ClientClanPlayerServiceImpl.kt
@@ -3,12 +3,10 @@ package dev.slne.surf.clan.core.client.services
 import com.google.auto.service.AutoService
 import dev.slne.clan.api.player.ClanPlayer
 import dev.slne.clan.api.player.ClanPlayerService
-import dev.slne.surf.clan.core.client.rabbit.rabbitApi
 import dev.slne.surf.clan.core.client.redis.RedisService
+import dev.slne.surf.clan.core.client.rpc.clanPlayerRpcService
 import dev.slne.surf.clan.core.player.ClanPlayerImpl
 import dev.slne.surf.clan.core.player.CoreClanPlayerService
-import dev.slne.surf.clan.core.protocol.player.findByUuid.FindClanPlayerByUuidRequestPacket
-import dev.slne.surf.clan.core.protocol.player.updateAccepsClanInvites.UpdateClanPlayerAcceptsInvitesRequestPacket
 import java.util.*
 import kotlin.time.Duration.Companion.minutes
 
@@ -25,7 +23,7 @@ class ClientClanPlayerServiceImpl : CoreClanPlayerService {
 
     override suspend fun findByUuid(uuid: UUID): ClanPlayer {
         return cache.cachedOrLoad(uuid) {
-            rabbitApi.sendRequest(FindClanPlayerByUuidRequestPacket(uuid)).player
+            clanPlayerRpcService.findClanPlayerByUuid(uuid)
         }
     }
 
@@ -33,8 +31,7 @@ class ClientClanPlayerServiceImpl : CoreClanPlayerService {
         playerImpl: ClanPlayerImpl,
         acceptsClanInvites: Boolean
     ): Boolean {
-        val request = UpdateClanPlayerAcceptsInvitesRequestPacket(playerImpl.ID, acceptsClanInvites)
-        val changed = rabbitApi.sendRequest(request).value
+        val changed = clanPlayerRpcService.updateAcceptsClanInvites(playerImpl.ID, acceptsClanInvites)
 
         if (changed) {
             cache.invalidate(playerImpl.uuid)

--- a/surf-clan-core/surf-clan-core-client/src/main/kotlin/dev/slne/surf/clan/core/client/services/ClientClanServiceImpl.kt
+++ b/surf-clan-core/surf-clan-core-client/src/main/kotlin/dev/slne/surf/clan/core/client/services/ClientClanServiceImpl.kt
@@ -16,21 +16,10 @@ import dev.slne.surf.clan.core.clan.AbstractClanView
 import dev.slne.surf.clan.core.clan.ClanImpl
 import dev.slne.surf.clan.core.clan.ClanTagRules
 import dev.slne.surf.clan.core.clan.CoreClanService
-import dev.slne.surf.clan.core.client.rabbit.rabbitApi
 import dev.slne.surf.clan.core.client.redis.RedisService
+import dev.slne.surf.clan.core.client.rpc.clanRpcService
 import dev.slne.surf.clan.core.invite.ClanInviteImpl
 import dev.slne.surf.clan.core.member.ClanMemberImpl
-import dev.slne.surf.clan.core.protocol.clan.create.CreateClanRequestPacket
-import dev.slne.surf.clan.core.protocol.clan.delete.DeleteClanRequestPacket
-import dev.slne.surf.clan.core.protocol.clan.findAllWithoutMembersSortByMemberCount.FindAllClansWithoutMembersSortByMemberCountRequestPacket
-import dev.slne.surf.clan.core.protocol.clan.findByID.FindClanByClanIDRequestPacket
-import dev.slne.surf.clan.core.protocol.clan.findByMember.FindClanByMemberRequestPacket
-import dev.slne.surf.clan.core.protocol.clan.findByTag.FindClanByTagRequestPacket
-import dev.slne.surf.clan.core.protocol.clan.findByUuid.FindClanByUuidRequestPacket
-import dev.slne.surf.clan.core.protocol.clan.findTagsByPrefixLimited.FindClanTagsByPrefixLimitedRequestPacket
-import dev.slne.surf.clan.core.protocol.clan.updateDescription.UpdateClanDescriptionRequestPacket
-import dev.slne.surf.clan.core.protocol.clan.updateDiscordInvite.UpdateClanDiscordInviteRequestPacket
-import dev.slne.surf.clan.core.protocol.clan.updateTagColor.UpdateClanTagColorRequestPacket
 import dev.slne.surf.redis.cache.RedisSetIndexes
 import it.unimi.dsi.fastutil.chars.Char2BooleanOpenHashMap
 import java.util.*
@@ -51,8 +40,7 @@ class ClientClanServiceImpl : CoreClanService {
         .maximumSize(5_000)
         .expireAfterWrite(1.minutes)
         .asLoadingCache<String, List<String>> { bucketKey ->
-            val request = FindClanTagsByPrefixLimitedRequestPacket(bucketKey, 100)
-            rabbitApi.sendRequest(request).tags
+            clanRpcService.findClanTagsByPrefix(bucketKey, 100)
         }
 
     private val listeners = CopyOnWriteArrayList<ClanListener>()
@@ -124,31 +112,30 @@ class ClientClanServiceImpl : CoreClanService {
 
     override suspend fun findClanByPlayer(playerUuid: UUID): Clan? {
         return cache.findCachedByIndexOrLoadNullable(CacheIndexes.members, playerUuid) {
-            rabbitApi.sendRequest(FindClanByMemberRequestPacket(playerUuid)).clan
+            clanRpcService.findClanByMember(playerUuid)
         }
     }
 
     override suspend fun findClanByUuid(clanUuid: UUID): Clan? {
         return cache.findCachedByIndexOrLoadNullable(CacheIndexes.uuid, clanUuid) {
-            rabbitApi.sendRequest(FindClanByUuidRequestPacket(clanUuid)).clan
+            clanRpcService.findClanByClanUuid(clanUuid)
         }
     }
 
     override suspend fun findClanByTag(tag: String): Clan? {
         return cache.findCachedByIndexOrLoadNullable(CacheIndexes.tag, tag) {
-            rabbitApi.sendRequest(FindClanByTagRequestPacket(normalizeTag(tag))).clan
+            clanRpcService.findClanByTag(normalizeTag(tag))
         }
     }
 
     override suspend fun findClanByID(id: ULong): ClanImpl? {
         return cache.findCachedByIndexOrLoadNullable(CacheIndexes.id, id) {
-            rabbitApi.sendRequest(FindClanByClanIDRequestPacket(id)).clan
+            clanRpcService.findClanById(id)
         }
     }
 
     override suspend fun fetchAllClansWithoutMembersSortByMemberCount(): Collection<ClanImpl> {
-        val request = FindAllClansWithoutMembersSortByMemberCountRequestPacket()
-        return rabbitApi.sendRequest(request).result
+        return clanRpcService.findAllClansWithoutMembersSortByMemberCount()
     }
 
     override fun validateClanNameAndTag(
@@ -184,7 +171,7 @@ class ClientClanServiceImpl : CoreClanService {
             return ClanCreationResult.InvalidTagOrName(nameTagValidation)
         }
 
-        val request = CreateClanRequestPacket(
+        val result = clanRpcService.createClan(
             properties.name,
             normalizeTag(properties.tag),
             properties.owner,
@@ -194,7 +181,6 @@ class ClientClanServiceImpl : CoreClanService {
             properties.description,
             properties.discordInvite
         )
-        val result = rabbitApi.sendRequest(request).result
 
         if (result is ClanCreationResult.Success) {
             callClanCreatedListeners(result.clan)
@@ -207,8 +193,7 @@ class ClientClanServiceImpl : CoreClanService {
         clan: ClanImpl,
         description: String?
     ): Boolean {
-        val request = UpdateClanDescriptionRequestPacket(clan.clanID, description)
-        val updated = rabbitApi.sendRequest(request).value
+        val updated = clanRpcService.updateClanDescription(clan.clanID, description)
 
         if (updated) {
             invalidateCachedClanByID(clan.clanID)
@@ -223,8 +208,7 @@ class ClientClanServiceImpl : CoreClanService {
         clan: ClanImpl,
         discordInvite: String?
     ): Boolean {
-        val request = UpdateClanDiscordInviteRequestPacket(clan.clanID, discordInvite)
-        val updated = rabbitApi.sendRequest(request).value
+        val updated = clanRpcService.updateClanDiscordInvite(clan.clanID, discordInvite)
 
         if (updated) {
             invalidateCachedClanByID(clan.clanID)
@@ -240,14 +224,12 @@ class ClientClanServiceImpl : CoreClanService {
         update: ClanTagColor.Update
     ): Boolean {
         val updatedTagColor = clan.clanTagColor.update(update)
-
-        val request = UpdateClanTagColorRequestPacket(
+        val updated = clanRpcService.updateClanTagColor(
             clan.clanID,
             updatedTagColor.foregroundColor,
             updatedTagColor.backgroundColor,
             updatedTagColor.shadowColor
         )
-        val updated = rabbitApi.sendRequest(request).value
 
         if (updated) {
             invalidateCachedClanByID(clan.clanID)
@@ -307,8 +289,7 @@ class ClientClanServiceImpl : CoreClanService {
     }
 
     override suspend fun delete(clan: ClanImpl): Boolean {
-        val request = DeleteClanRequestPacket(clan.clanID)
-        val deleted = rabbitApi.sendRequest(request).value
+        val deleted = clanRpcService.deleteClan(clan.clanID)
 
         if (deleted) {
             invalidateCachedClanByID(clan.clanID)

--- a/surf-clan-microservice/src/main/kotlin/dev/slne/surf/clan/microservice/ClanMicroservice.kt
+++ b/surf-clan-microservice/src/main/kotlin/dev/slne/surf/clan/microservice/ClanMicroservice.kt
@@ -3,6 +3,9 @@ package dev.slne.surf.clan.microservice
 import com.google.auto.service.AutoService
 import dev.slne.surf.clan.core.ClanCoreSerializerModule
 import dev.slne.surf.clan.core.ClanInstance
+import dev.slne.surf.clan.core.rpc.ClanInviteRpcService
+import dev.slne.surf.clan.core.rpc.ClanMemberRpcService
+import dev.slne.surf.clan.core.rpc.ClanPlayerRpcService
 import dev.slne.surf.clan.core.rpc.ClanRpcService
 import dev.slne.surf.clan.microservice.db.table.ClanInvitesTable
 import dev.slne.surf.clan.microservice.db.table.ClanMembersTable
@@ -16,6 +19,9 @@ import dev.slne.surf.clan.microservice.handler.member.DeleteClanMemberHandler
 import dev.slne.surf.clan.microservice.handler.member.FindClanMemberByUuidHandler
 import dev.slne.surf.clan.microservice.handler.player.FindClanPlayerByUuidHandler
 import dev.slne.surf.clan.microservice.handler.player.UpdateClanPlayerAcceptsInvitesHandler
+import dev.slne.surf.clan.microservice.rpc.ClanInviteRpcServiceImpl
+import dev.slne.surf.clan.microservice.rpc.ClanMemberRpcServiceImpl
+import dev.slne.surf.clan.microservice.rpc.ClanPlayerRpcServiceImpl
 import dev.slne.surf.clan.microservice.rpc.ClanRpcServiceImpl
 import dev.slne.surf.database.DatabaseApi
 import dev.slne.surf.database.libs.org.jetbrains.exposed.v1.r2dbc.SchemaUtils
@@ -74,6 +80,9 @@ class ClanMicroservice : Microservice() {
         rabbitApi.registerRequestHandler(UpdateClanPlayerAcceptsInvitesHandler)
 
         rabbitApi.registerRpcService<ClanRpcService>(ClanRpcServiceImpl)
+        rabbitApi.registerRpcService<ClanInviteRpcService>(ClanInviteRpcServiceImpl)
+        rabbitApi.registerRpcService<ClanMemberRpcService>(ClanMemberRpcServiceImpl)
+        rabbitApi.registerRpcService<ClanPlayerRpcService>(ClanPlayerRpcServiceImpl)
 
         rabbitApi.freezeAndConnect()
     }

--- a/surf-clan-microservice/src/main/kotlin/dev/slne/surf/clan/microservice/ClanMicroservice.kt
+++ b/surf-clan-microservice/src/main/kotlin/dev/slne/surf/clan/microservice/ClanMicroservice.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.clan.microservice
 import com.google.auto.service.AutoService
 import dev.slne.surf.clan.core.ClanCoreSerializerModule
 import dev.slne.surf.clan.core.ClanInstance
+import dev.slne.surf.clan.core.rpc.ClanRpcService
 import dev.slne.surf.clan.microservice.db.table.ClanInvitesTable
 import dev.slne.surf.clan.microservice.db.table.ClanMembersTable
 import dev.slne.surf.clan.microservice.db.table.ClanPlayerTable
@@ -15,6 +16,7 @@ import dev.slne.surf.clan.microservice.handler.member.DeleteClanMemberHandler
 import dev.slne.surf.clan.microservice.handler.member.FindClanMemberByUuidHandler
 import dev.slne.surf.clan.microservice.handler.player.FindClanPlayerByUuidHandler
 import dev.slne.surf.clan.microservice.handler.player.UpdateClanPlayerAcceptsInvitesHandler
+import dev.slne.surf.clan.microservice.rpc.ClanRpcServiceImpl
 import dev.slne.surf.database.DatabaseApi
 import dev.slne.surf.database.libs.org.jetbrains.exposed.v1.r2dbc.SchemaUtils
 import dev.slne.surf.database.libs.org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
@@ -70,6 +72,8 @@ class ClanMicroservice : Microservice() {
         // Player
         rabbitApi.registerRequestHandler(FindClanPlayerByUuidHandler)
         rabbitApi.registerRequestHandler(UpdateClanPlayerAcceptsInvitesHandler)
+
+        rabbitApi.registerRpcService<ClanRpcService>(ClanRpcServiceImpl)
 
         rabbitApi.freezeAndConnect()
     }

--- a/surf-clan-microservice/src/main/kotlin/dev/slne/surf/clan/microservice/rpc/ClanInviteRpcServiceImpl.kt
+++ b/surf-clan-microservice/src/main/kotlin/dev/slne/surf/clan/microservice/rpc/ClanInviteRpcServiceImpl.kt
@@ -1,0 +1,55 @@
+package dev.slne.surf.clan.microservice.rpc
+
+import dev.slne.clan.api.invite.ClanInviteResult
+import dev.slne.surf.clan.core.invite.ClanInviteImpl
+import dev.slne.surf.clan.core.rpc.ClanInviteRpcService
+import dev.slne.surf.clan.microservice.db.repository.ClanInviteRepository
+import java.util.*
+
+object ClanInviteRpcServiceImpl : ClanInviteRpcService {
+    override suspend fun acceptInvite(
+        inviteID: ULong,
+        invitee: UUID,
+        invitedBy: UUID
+    ): Boolean {
+        return ClanInviteRepository.acceptInvite(
+            inviteID = inviteID,
+            invitee = invitee,
+            invitedBy = invitedBy
+        )
+    }
+
+    override suspend fun createInvite(
+        clanID: ULong,
+        invitee: UUID,
+        invitedBy: UUID
+    ): ClanInviteResult {
+        return ClanInviteRepository.createInvite(
+            clanID = clanID,
+            invitee = invitee,
+            invitedBy = invitedBy
+        )
+    }
+
+    override suspend fun deleteInvite(clanID: ULong, invitee: UUID): Boolean {
+        return ClanInviteRepository.deleteInvite(clanID, invitee)
+    }
+
+    override suspend fun findPendingInvitesByClanId(clanID: ULong): Set<ClanInviteImpl> {
+        return ClanInviteRepository.fetchPendingInvites(clanID)
+    }
+
+    override suspend fun findPendingInvitesByInvited(invited: UUID): List<ClanInviteImpl> {
+        return ClanInviteRepository.getPendingInvitesByPlayer(invited)
+    }
+
+    override suspend fun findPendingInviteByClanNameAndInvited(
+        clanName: String,
+        invited: UUID
+    ): ClanInviteImpl? {
+        return ClanInviteRepository.getPendingInviteByPlayerAndClanName(
+            invited = invited,
+            clanName = clanName
+        )
+    }
+}

--- a/surf-clan-microservice/src/main/kotlin/dev/slne/surf/clan/microservice/rpc/ClanMemberRpcServiceImpl.kt
+++ b/surf-clan-microservice/src/main/kotlin/dev/slne/surf/clan/microservice/rpc/ClanMemberRpcServiceImpl.kt
@@ -1,0 +1,39 @@
+package dev.slne.surf.clan.microservice.rpc
+
+import dev.slne.clan.api.member.ClanMemberAddResult
+import dev.slne.clan.api.member.ClanMemberRole
+import dev.slne.surf.clan.core.member.ClanMemberImpl
+import dev.slne.surf.clan.core.rpc.ClanMemberRpcService
+import dev.slne.surf.clan.microservice.db.repository.ClanMemberRepository
+import java.util.*
+
+object ClanMemberRpcServiceImpl : ClanMemberRpcService {
+    override suspend fun createMember(
+        clanID: ULong,
+        player: UUID,
+        role: ClanMemberRole,
+        invitedBy: UUID?
+    ): ClanMemberAddResult {
+        return ClanMemberRepository.createMember(
+            clanID = clanID,
+            player = player,
+            role = role,
+            invitedBy = invitedBy
+        )
+    }
+
+    override suspend fun deleteMember(clanID: ULong, player: UUID): Boolean {
+        return ClanMemberRepository.deleteMember(clanID, player)
+    }
+
+    override suspend fun changeMemberRole(
+        memberID: ULong,
+        role: ClanMemberRole
+    ): Boolean {
+        return ClanMemberRepository.changeRole(memberID, role)
+    }
+
+    override suspend fun findMemberByUUID(uuid: UUID): ClanMemberImpl? {
+        return ClanMemberRepository.findByUuid(uuid)
+    }
+}

--- a/surf-clan-microservice/src/main/kotlin/dev/slne/surf/clan/microservice/rpc/ClanPlayerRpcServiceImpl.kt
+++ b/surf-clan-microservice/src/main/kotlin/dev/slne/surf/clan/microservice/rpc/ClanPlayerRpcServiceImpl.kt
@@ -1,0 +1,20 @@
+package dev.slne.surf.clan.microservice.rpc
+
+import dev.slne.surf.clan.core.player.ClanPlayerImpl
+import dev.slne.surf.clan.core.rpc.ClanPlayerRpcService
+import dev.slne.surf.clan.microservice.db.repository.ClanPlayerRepository
+import java.util.*
+
+object ClanPlayerRpcServiceImpl : ClanPlayerRpcService {
+
+    override suspend fun findClanPlayerByUuid(uuid: UUID): ClanPlayerImpl {
+        return ClanPlayerRepository.findOrCreateByUuid(uuid)
+    }
+
+    override suspend fun updateAcceptsClanInvites(
+        playerID: ULong,
+        acceptsClanInvites: Boolean
+    ): Boolean {
+        return ClanPlayerRepository.changeAcceptsClanInvites(playerID, acceptsClanInvites)
+    }
+}

--- a/surf-clan-microservice/src/main/kotlin/dev/slne/surf/clan/microservice/rpc/ClanRpcServiceImpl.kt
+++ b/surf-clan-microservice/src/main/kotlin/dev/slne/surf/clan/microservice/rpc/ClanRpcServiceImpl.kt
@@ -1,0 +1,86 @@
+package dev.slne.surf.clan.microservice.rpc
+
+import dev.slne.clan.api.clan.ClanCreationResult
+import dev.slne.surf.clan.core.clan.ClanImpl
+import dev.slne.surf.clan.core.rpc.ClanRpcService
+import dev.slne.surf.clan.microservice.db.repository.ClanRepository
+import net.kyori.adventure.text.format.ShadowColor
+import net.kyori.adventure.text.format.TextColor
+import java.util.*
+
+object ClanRpcServiceImpl : ClanRpcService {
+    override suspend fun createClan(
+        name: String,
+        tag: String,
+        owner: UUID,
+        tagForegroundColor: TextColor?,
+        tagBackgroundColor: TextColor?,
+        tagShadowColor: ShadowColor?,
+        description: String?,
+        discordInvite: String?
+    ): ClanCreationResult {
+        return ClanRepository.create(
+            name = name,
+            tag = tag,
+            owner = owner,
+            tagForegroundColor = tagForegroundColor,
+            tagBackgroundColor = tagBackgroundColor,
+            tagShadowColor = tagShadowColor,
+            description = description,
+            discordInvite = discordInvite
+        )
+    }
+
+    override suspend fun deleteClan(clanID: ULong): Boolean {
+        return ClanRepository.delete(clanID)
+    }
+
+    override suspend fun findAllClansWithoutMembersSortByMemberCount(): Collection<ClanImpl> {
+        return ClanRepository.fetchAllClansWithoutMembersSortByMemberCount()
+    }
+
+    override suspend fun findClanById(clanID: ULong): ClanImpl? {
+        return ClanRepository.findClanByID(clanID)
+    }
+
+    override suspend fun findClanByMember(memberUuid: UUID): ClanImpl? {
+        return ClanRepository.findClanByPlayer(memberUuid)
+    }
+
+    override suspend fun findClanByTag(tag: String): ClanImpl? {
+        return ClanRepository.findClanByTag(tag)
+    }
+
+    override suspend fun findClanByClanUuid(clanUuid: UUID): ClanImpl? {
+        return ClanRepository.findClanByUuid(clanUuid)
+    }
+
+    override suspend fun findClanTagsByPrefix(
+        prefix: String,
+        limit: Int
+    ): List<String> {
+        return ClanRepository.suggestTagsByPrefix(prefix, limit)
+    }
+
+    override suspend fun updateClanDescription(clanID: ULong, description: String?): Boolean {
+        return ClanRepository.updateDescription(clanID, description)
+    }
+
+    override suspend fun updateClanDiscordInvite(clanID: ULong, discordInvite: String?): Boolean {
+        return ClanRepository.updateDiscordInvite(clanID, discordInvite)
+    }
+
+    override suspend fun updateClanTagColor(
+        clanID: ULong,
+        tagForegroundColor: TextColor?,
+        tagBackgroundColor: TextColor?,
+        tagShadowColor: ShadowColor?
+    ): Boolean {
+        return ClanRepository.updateTagColor(
+            clanID = clanID,
+            tagForegroundColor = tagForegroundColor,
+            tagBackgroundColor = tagBackgroundColor,
+            tagShadowColor = tagShadowColor
+        )
+    }
+}


### PR DESCRIPTION
This pull request introduces a major refactor of the clan services communication layer, replacing the previous protocol-packet-based RabbitMQ requests with type-safe Kotlin RPC service interfaces. This change significantly improves maintainability, readability, and type safety across the codebase. Additionally, four new RPC service interfaces are added, and all client service implementations are updated to use these new interfaces. The project version is also bumped.

### Migration to type-safe RPC services

**New RPC service interfaces:**
* Added `ClanRpcService`, `ClanInviteRpcService`, `ClanMemberRpcService`, and `ClanPlayerRpcService` interfaces in `surf-clan-core/src/main/kotlin/dev/slne/surf/clan/core/rpc/`, each annotated with `@RpcService` and defining all clan-related operations. [[1]](diffhunk://#diff-062dee6249be927dce2e8ba4b605965bd18ed8a774bbb9e02cd959f78606d0a2R1-R41) [[2]](diffhunk://#diff-3cb4f4356133ebc8b86f686c91e70fcd0e44810e0c2c77f56892d9ed38a892d6R1-R18) [[3]](diffhunk://#diff-e444b0f00cdb886ef12c67ebf406caf1eca09fda36c6b6631b832969c55ba533R1-R18) [[4]](diffhunk://#diff-d4ac0eff328806b123d540dbec0012e033e19055908ed84f97be4d3788ffbee3R1-R13)
* Registered these services for client use in `RpcServices.kt`, exposing lazy singletons for each service.

**Client service refactoring:**
* All usages of the old `rabbitApi.sendRequest` with protocol packets in client service implementations are replaced with calls to the appropriate RPC service interface methods. This affects clan, invite, member, and player client services. [[1]](diffhunk://#diff-d1ac2b99c0c6157c714fd14126e2175613057b7c0264532da639dd7b8a2c21e0L9-R48) [[2]](diffhunk://#diff-819a5c22759095655d7d97552f9cd6d1aafb7ea9fd509cff4d9fdf33e9faa245L13-L19) [[3]](diffhunk://#diff-cad2dfd3bdb678e3132057bea1b7269cf3d95f7330364693dfe53e4d2e544227L6-L11) [[4]](diffhunk://#diff-1ccc5e42766105b2be9680bf5cba36219285b7b9eaafe766ea85095fcab3dda6L19-L33) and related lines)

### Code cleanup and simplification

* Removed all imports and usages of protocol packet classes in client services, leading to cleaner and more maintainable code. [[1]](diffhunk://#diff-d1ac2b99c0c6157c714fd14126e2175613057b7c0264532da639dd7b8a2c21e0L9-R48) [[2]](diffhunk://#diff-819a5c22759095655d7d97552f9cd6d1aafb7ea9fd509cff4d9fdf33e9faa245L13-L19) [[3]](diffhunk://#diff-cad2dfd3bdb678e3132057bea1b7269cf3d95f7330364693dfe53e4d2e544227L6-L11) [[4]](diffhunk://#diff-1ccc5e42766105b2be9680bf5cba36219285b7b9eaafe766ea85095fcab3dda6L19-L33)
* Updated all relevant methods to directly return results from the new RPC service methods, removing unnecessary request/response wrapping. [[1]](diffhunk://#diff-819a5c22759095655d7d97552f9cd6d1aafb7ea9fd509cff4d9fdf33e9faa245L73-R69) [[2]](diffhunk://#diff-819a5c22759095655d7d97552f9cd6d1aafb7ea9fd509cff4d9fdf33e9faa245L86-R81) [[3]](diffhunk://#diff-819a5c22759095655d7d97552f9cd6d1aafb7ea9fd509cff4d9fdf33e9faa245L97-R91) [[4]](diffhunk://#diff-819a5c22759095655d7d97552f9cd6d1aafb7ea9fd509cff4d9fdf33e9faa245L111-R104) [[5]](diffhunk://#diff-cad2dfd3bdb678e3132057bea1b7269cf3d95f7330364693dfe53e4d2e544227L28-R34) [[6]](diffhunk://#diff-1ccc5e42766105b2be9680bf5cba36219285b7b9eaafe766ea85095fcab3dda6L54-R43) [[7]](diffhunk://#diff-1ccc5e42766105b2be9680bf5cba36219285b7b9eaafe766ea85095fcab3dda6L127-R138) [[8]](diffhunk://#diff-1ccc5e42766105b2be9680bf5cba36219285b7b9eaafe766ea85095fcab3dda6L187-R174) [[9]](diffhunk://#diff-1ccc5e42766105b2be9680bf5cba36219285b7b9eaafe766ea85095fcab3dda6L197) [[10]](diffhunk://#diff-1ccc5e42766105b2be9680bf5cba36219285b7b9eaafe766ea85095fcab3dda6L210-R196)

### Version update

* Bumped project version from `2.1.1` to `2.1.2` in `gradle.properties`.